### PR TITLE
Idle deloads

### DIFF
--- a/goal_src/jak1/engine/game/game-info-h.gc
+++ b/goal_src/jak1/engine/game/game-info-h.gc
@@ -108,6 +108,7 @@
   (contf09)
   (game-start)
   (sage-ecorocks)
+  (ignore-closest-search) ;; PATCHED - added this to block certain continue points from being considered for idle deload
   )
 
 ;; static data for a continue point

--- a/goal_src/jak1/engine/level/level-info.gc
+++ b/goal_src/jak1/engine/level/level-info.gc
@@ -1019,6 +1019,7 @@
       (new 'static 'continue-point
         :name "ogre-race"
         :level 'ogre
+        :flags (continue-flags ignore-closest-search) ;; PATCHED - prevent klaww skip (thru idle deload)
         :trans (new 'static 'vector :x 841424.9 :y 163801.1 :z -8205419.5 :w 1.0)
         :quat (new 'static 'quaternion :y -0.9857 :w 0.168)
         :camera-trans (new 'static 'vector :x 860479.9 :y 183815.38 :z -8162368.0 :w 1.0)
@@ -1483,6 +1484,7 @@
       (new 'static 'continue-point
         :name "lavatube-middle"
         :level 'lavatube
+        :flags (continue-flags ignore-closest-search) ;; PATCHED - prevent LTS (thru idle deload)
         :trans (new 'static 'vector :x 9081441.0 :y -3935.8464 :z -14056285.0 :w 1.0)
         :quat (new 'static 'quaternion :y -0.7002 :w -0.7139)
         :camera-trans (new 'static 'vector :x 9055362.0 :y 10606.592 :z -14050822.0 :w 1.0)
@@ -1596,6 +1598,7 @@
       (new 'static 'continue-point
         :name "citadel-launch-start"
         :level 'citadel
+        :flags (continue-flags ignore-closest-search) ;; PATCHED - prevent all orbs deload into citadel
         :trans (new 'static 'vector :x 10827551.0 :y -94047.02 :z -18946718.0 :w 1.0)
         :quat (new 'static 'quaternion :y 0.8377 :w -0.546)
         :camera-trans (new 'static 'vector :x 10862150.0 :y -75343.875 :z -18922316.0 :w 1.0)

--- a/goal_src/jak1/engine/level/level.gc
+++ b/goal_src/jak1/engine/level/level.gc
@@ -1920,7 +1920,7 @@
                    )
               (while (not (null? s4-2))
                 (if (and (< (vector-vector-distance s2-0 (-> s1-0 trans)) (vector-vector-distance s2-0 (-> s3-0 trans)))
-                    (zero? (-> s1-0 flags))
+                    (zero? (-> s1-0 flags)) ;; PATCHED - we added flags to certain continue points to prevent skips using idle deload
                     )
                   (set! s3-0 s1-0)
                   )

--- a/goal_src/jak1/engine/target/target2.gc
+++ b/goal_src/jak1/engine/target/target2.gc
@@ -117,7 +117,8 @@
     (if (or (cpad-hold? (-> self control unknown-cpad-info00 number) start l1 r1 triangle circle x square)
             *progress-process*
             )
-        (go target-stance)
+        (suspend) ;; PATCHED - don't abort idle animation if holding face button or pause (buffered)
+        ;; (go target-stance)
         )
     )
   :code (behavior ()


### PR DESCRIPTION
did 2 things here just to be safe

1 - prevented the idle animation cancel (via both holding face button or being pause/pause-buffered)
2 - just in case someone finds some other method of doing an idle deload, I added a flag to certain continue-points (LTS, klaww, all orbs into citadel) so they get ignored in the "closest continue point" logic