### PR TITLE
FCS tings

### DIFF
--- a/goal_src/jak1/engine/collide/collide-shape.gc
+++ b/goal_src/jak1/engine/collide/collide-shape.gc
@@ -843,14 +843,16 @@
            )
       ;; note: the above limit is the same as the limit passed into find-ground-point. So the limiting should only kick in
       ;; if we use last safe ground.
-      (cond
-        ((< (fabs (vector-dot
-                    (-> arg0 control dynam gravity-normal)
-                    (vector-! (new 'stack-no-clear 'vector) s4-0 (-> arg0 control trans))
-                    )
-                  )
-            (meters 10)
-            )
+
+      ;; PATCHED - never fall back to FCS bounces, always jump towards ground point
+      ;; (cond
+      ;;   ((< (fabs (vector-dot
+      ;;               (-> arg0 control dynam gravity-normal)
+      ;;               (vector-! (new 'stack-no-clear 'vector) s4-0 (-> arg0 control trans))
+      ;;               )
+      ;;             )
+      ;;       (meters 10)
+      ;;       )
          ;; if we reach here, we have to jump up or down less than 10m.
          ;; reduce our jump direction to within reasonable distance
          (vector-xz-normalize! s2-1 f30-1)
@@ -870,20 +872,19 @@
               )
              )
            )
-         )
-        (else
-          ;; the last safest place we jumped is too high. just launch jak in the air and hope for the best.
-          ;; fire canyon skip jumps
-          (send-event arg0 arg1 #f (static-attack-info ((mode arg2)
-                                                        (vector (new 'static 'vector :y (meters 10) :w 1.0))
-                                                        (shove-up (meters 10))
-                                                        (angle 'up)
-                                                        (control 1.0)
-                                                        )
-                                                       )
-                      )
-          )
-        )
+        ;;  )
+        ;; (else
+        ;;   ;; the last safest place we jumped is too high. just launch jak in the air and hope for the best.
+        ;;   ;; fire canyon skip jumps
+        ;;   (send-event arg0 arg1 #f (static-attack-info ((mode arg2)
+        ;;                                                 (vector (new 'static 'vector :y (meters 10) :w 1.0))
+        ;;                                                 (shove-up (meters 10))
+        ;;                                                 (angle 'up)
+        ;;                                                 (control 1.0)
+        ;;                                                 )
+        ;;                                                )
+        ;;               )
+        ;;   )
       )
     )
   (none)

--- a/goal_src/jak1/engine/game/main.gc
+++ b/goal_src/jak1/engine/game/main.gc
@@ -655,7 +655,10 @@
       (with-profiler "menu"
         (#when PC_PORT
           (if (and *display-sha* *debug-segment*)
-            (draw-build-revision)))
+            (draw-build-revision))
+          (if (and *display-last-ground-point* *debug-segment*)
+            (draw-last-known-safe-ground))
+            )
         (*menu-hook*)
         (add-ee-profile-frame 'draw :g #x40)
 

--- a/goal_src/jak1/engine/target/logic-target.gc
+++ b/goal_src/jak1/engine/target/logic-target.gc
@@ -1988,6 +1988,8 @@
   (backup-collide-with-as (-> self control))
   (set! (-> self game) *game-info*)
   (move-to-point! (-> self control) (-> arg0 trans))
+  ;; PATCHED - use continue point itself as last-known-safe-ground upon spawn (instead of 0,0,0)
+  (set! (-> self control last-known-safe-ground quad) (-> self control trans quad))
   (set! (-> (&-> (-> self control) unknown-qword00) 0) (-> arg0 trans quad))
   (set! (-> self control unknown-cpad-info00) (-> *cpad-list* cpads 0))
   (set! (-> self control unknown-surface01) (new 'process 'surface))

--- a/goal_src/jak1/pc/debug/default-menu-pc.gc
+++ b/goal_src/jak1/pc/debug/default-menu-pc.gc
@@ -838,6 +838,7 @@
          (flag "PS2 Actor vis" #f ,(dm-lambda-boolean-flag (-> *pc-settings* ps2-actor-vis?)))
          (flag "Display actor counts" *display-actor-counts* dm-boolean-toggle-pick-func)
          (flag "Display git commit" *display-sha* dm-boolean-toggle-pick-func)
+         (flag "Display last known safe ground" *display-last-ground-point* dm-boolean-toggle-pick-func)
          (flag "Extra hud elements" #f ,(dm-lambda-boolean-flag (-> *pc-settings* extra-hud?)))
          (flag "Music fadein" #f ,(dm-lambda-boolean-flag (-> *pc-settings* music-fadein?)))
          (flag "Music fadeout" #f ,(dm-lambda-boolean-flag (-> *pc-settings* music-fadeout?)))

--- a/goal_src/jak1/pc/pckernel-h.gc
+++ b/goal_src/jak1/pc/pckernel-h.gc
@@ -282,6 +282,7 @@
 (define *display-actor-counts* #f)
 (define *display-text-box* #f)
 (define *display-sha* *debug-segment*)
+(define *display-last-ground-point* #f)
 
 ;; collision renderer things. debug only.
 (define *collision-renderer* #f)

--- a/goal_src/jak1/pc/pckernel.gc
+++ b/goal_src/jak1/pc/pckernel.gc
@@ -624,6 +624,16 @@
                           (font-color flat-yellow)
                           (font-flags shadow kerning))))
 
+(defun draw-last-known-safe-ground ()
+  (with-dma-buffer-add-bucket ((buf (-> (current-frame) global-buf))
+                                     (bucket-id debug-no-zbuf))
+    (when *target*
+      (let ((vec (-> *target* control last-known-safe-ground)))
+          (draw-string-xy (string-format "~M ~M ~M" (-> vec x) (-> vec y) (-> vec z))
+                          buf
+                          0 (+ 10 (* 10 (-> (get-video-params) relative-y-scale)))
+                          (font-color flat-yellow)
+                          (font-flags shadow kerning))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; process pools


### PR DESCRIPTION
- debug text option for last-known-safe-ground
- on load/respawn, sets last-known-safe-ground to the continue point location
- disabled the branch of code responsible for FCS-style bounces in `target-attack-up`, so even if the last point is >10m away its always used

technically 3-frame jumps are still a thing, e.g. you can delay taking fall damage by chaining them.